### PR TITLE
Refine episode page and nav

### DIFF
--- a/apps/site-v2/src/app/footer.tsx
+++ b/apps/site-v2/src/app/footer.tsx
@@ -1,8 +1,8 @@
-import { Rss } from "lucide-react";
 import { Anchor } from "#components/anchor";
 import { ApplePodcasts } from "#components/apple-podcasts.js";
 import { Bluesky } from "#components/bluesky.js";
 import { Discord } from "#components/discord.js";
+import { Rss } from "#components/rss";
 import { Spotify } from "#components/spotify.js";
 import { hosts } from "../hosts";
 import type { Host } from "../types";

--- a/apps/site-v2/src/app/nav.tsx
+++ b/apps/site-v2/src/app/nav.tsx
@@ -1,5 +1,8 @@
 import { Link } from "waku";
+import { Anchor } from "#components/anchor.js";
+import { ApplePodcasts } from "#components/apple-podcasts.js";
 import { Logo } from "#components/logo";
+import { Spotify } from "#components/spotify.js";
 import { Button } from "#components/ui/button";
 
 export function Nav() {
@@ -10,12 +13,17 @@ export function Nav() {
           <Logo />
         </Link>
         <div className="flex items-center gap-2 text-xl">
-          <Button asChild variant="link">
-            <Link to="/about">About</Link>
-          </Button>
-          <Button asChild variant="link">
-            <Link to="/search">Search</Link>
-          </Button>
+          <Anchor href="/about">About</Anchor>
+          <Anchor href="/search">Search</Anchor>
+          <Anchor href="/episodes">All Episodes</Anchor>
+          <Anchor href="https://open.spotify.com/show/7njrdM3LvNPnqSftswTkjn?si=5cc424416eaa4b35">
+            <Spotify className="w-6 h-6" />{" "}
+            <span className="sr-only">Find us on Spotify</span>
+          </Anchor>
+          <Anchor href="https://podcasts.apple.com/us/podcast/the-bikeshed-pod/id1802688284">
+            <ApplePodcasts className="w-6 h-6" />{" "}
+            <span className="sr-only">Find us on Apple Podcasts</span>
+          </Anchor>
         </div>
       </nav>
     </header>

--- a/apps/site-v2/src/app/nav.tsx
+++ b/apps/site-v2/src/app/nav.tsx
@@ -2,8 +2,8 @@ import { Link } from "waku";
 import { Anchor } from "#components/anchor.js";
 import { ApplePodcasts } from "#components/apple-podcasts.js";
 import { Logo } from "#components/logo";
+import { Rss } from "#components/rss";
 import { Spotify } from "#components/spotify.js";
-import { Button } from "#components/ui/button";
 
 export function Nav() {
   return (
@@ -23,6 +23,10 @@ export function Nav() {
           <Anchor href="https://podcasts.apple.com/us/podcast/the-bikeshed-pod/id1802688284">
             <ApplePodcasts className="w-6 h-6" />{" "}
             <span className="sr-only">Find us on Apple Podcasts</span>
+          </Anchor>
+          <Anchor href="/rss.xml" target="_blank" rel="noreferrer">
+            <Rss className="w-6 h-6" />{" "}
+            <span className="sr-only">Follow our RSS feed</span>
           </Anchor>
         </div>
       </nav>

--- a/apps/site-v2/src/components/bluesky-social.tsx
+++ b/apps/site-v2/src/components/bluesky-social.tsx
@@ -3,7 +3,6 @@
 import { Share } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
-import { Button } from "#components/ui/button";
 import { Anchor } from "./anchor";
 import { Bluesky } from "./bluesky";
 
@@ -35,15 +34,9 @@ export function SeeDiscussionOnBluesky({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <Button asChild variant="link">
-      <a
-        href={`https://bsky.app/search?q=${encodeURIComponent(url)}`}
-        target="_blank"
-        rel="noreferrer"
-      >
-        <Bluesky className="w-4 h-4 mr-2" />
-        {children}
-      </a>
-    </Button>
+    <Anchor href={`https://bsky.app/search?q=${encodeURIComponent(url)}`}>
+      <Bluesky className="w-4 h-4 mr-2" />
+      {children}
+    </Anchor>
   );
 }

--- a/apps/site-v2/src/components/bluesky-social.tsx
+++ b/apps/site-v2/src/components/bluesky-social.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { Share } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Button } from "#components/ui/button";
+import { Anchor } from "./anchor";
 import { Bluesky } from "./bluesky";
 
 export function ShareToBluesky({
@@ -16,16 +18,12 @@ export function ShareToBluesky({
   }, []);
 
   return (
-    <Button asChild variant="link">
-      <a
-        href={`https://bsky.app/intent/compose?text=${encodeURIComponent(`${title}: ${url}`)}`}
-        target="_blank"
-        rel="noreferrer"
-      >
-        <Bluesky className="w-4 h-4 mr-2" />
-        {children}
-      </a>
-    </Button>
+    <Anchor
+      href={`https://bsky.app/intent/compose?text=${encodeURIComponent(`${title}: ${url}`)}`}
+    >
+      <Share className="w-4 h-4 mr-2" />
+      {children}
+    </Anchor>
   );
 }
 

--- a/apps/site-v2/src/components/episode-container.tsx
+++ b/apps/site-v2/src/components/episode-container.tsx
@@ -1,6 +1,5 @@
 import { CommentSection } from "@hamstack/bluesky-comments";
 import { Heading } from "@local/components/heading";
-import { Button } from "#ui/button";
 import { hosts } from "../hosts";
 import type { HydratedFrontmatter } from "../types";
 import type { Host } from "../types";
@@ -68,15 +67,9 @@ export function EpisodeContainer({
               return (
                 <li key={host.name}>
                   {host.name} -{" "}
-                  <Button asChild variant="link">
-                    <a
-                      target="_blank"
-                      href={preferredSocial.url}
-                      rel="noreferrer"
-                    >
-                      {preferredSocial.network}
-                    </a>
-                  </Button>
+                  <Anchor href={preferredSocial.url} target="_blank">
+                    {preferredSocial.network}
+                  </Anchor>
                 </li>
               );
             })}

--- a/apps/site-v2/src/components/episode-container.tsx
+++ b/apps/site-v2/src/components/episode-container.tsx
@@ -4,8 +4,11 @@ import { Button } from "#ui/button";
 import { hosts } from "../hosts";
 import type { HydratedFrontmatter } from "../types";
 import type { Host } from "../types";
+import { Anchor } from "./anchor";
+import { ApplePodcasts } from "./apple-podcasts";
 import { SeeDiscussionOnBluesky, ShareToBluesky } from "./bluesky-social";
 import { EpisodeMeta } from "./episode-meta";
+import { Spotify } from "./spotify";
 
 function getPreferredSocial(host: Host): { network: string; url: string } {
   const website = host.socials.website;
@@ -87,6 +90,14 @@ export function EpisodeContainer({
           <source src={frontmatter.audioURL} type="audio/mpeg" />
           <track kind="captions" src={frontmatter.captionURL} />
         </audio>
+        <div className="flex flex-col md:flex-row gap-2 justify-center">
+          <Anchor href="https://open.spotify.com/show/7njrdM3LvNPnqSftswTkjn?si=5cc424416eaa4b35">
+            <Spotify className="w-4 h-4 mr-2" /> Listen on Spotify
+          </Anchor>
+          <Anchor href="https://podcasts.apple.com/us/podcast/the-bikeshed-pod/id1802688284">
+            <ApplePodcasts className="w-4 h-4 mr-2" /> Listen on Apple Podcasts
+          </Anchor>
+        </div>
         <div className="flex flex-col md:flex-row gap-2 justify-center">
           <ShareToBluesky
             title={`The Bikeshed Podcast episode: ${frontmatter.episodeId} - ${frontmatter.title}`}

--- a/apps/site-v2/src/components/rss.tsx
+++ b/apps/site-v2/src/components/rss.tsx
@@ -1,0 +1,76 @@
+import type { SVGProps } from "react";
+
+interface LogoIconProps {
+  attributes?: SVGProps<SVGSVGElement>;
+  className?: string;
+}
+
+export function Rss({
+  attributes = { role: "graphics-symbol" },
+  className,
+}: LogoIconProps) {
+  return (
+    <svg
+      {...attributes}
+      className={className}
+      width="120"
+      height="120"
+      viewBox="0 0 31.75 31.75"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>RSS</title>
+      <g id="layer1">
+        <g
+          id="g683"
+          transform="matrix(0.26458333,0,0,0.26458333,-8.8489774,-15.621043)"
+        >
+          <rect
+            style={{
+              fill: "#ff7f2a",
+              strokeWidth: "0.635",
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+            }}
+            width="100"
+            height="100"
+            x="43.444954"
+            y="69.040161"
+            rx="21.251678"
+            ry="21.251678"
+          />
+          <ellipse
+            style={{
+              fill: "#f2f2f2",
+              strokeWidth: "1.20348",
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+            }}
+            cx="69.901382"
+            cy="141.92136"
+            rx="10.357387"
+            ry="10.120168"
+          />
+          <path
+            style={{
+              fill: "#f2f2f2",
+              strokeWidth: "0.635",
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+            }}
+            d="m 59.835641,106.93038 v 10.80296 a 35.029171,35.029171 0 0 1 34.874357,34.87384 h 10.802442 a 45.676788,45.676788 0 0 0 -45.676799,-45.6768 z"
+          />
+          <path
+            style={{
+              fill: "#f2f2f2",
+              strokeWidth: "0.87785",
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+            }}
+            d="m -81.988277,59.856295 c 0,0 -10.066183,0.06645 -10.117729,0.122473 -5.28e-4,33.446743 -27.088614,60.574142 -60.535324,60.623172 v 9.90689 c 39.02047,1.7e-4 70.652935,-31.632064 70.653053,-70.652535 z"
+            transform="rotate(-90)"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Core Changes:

- Add Spotify + Apple Podcasts + RSS icon links to the nav
- Add `Listen on Spotify` and `Listen on Apple Podcasts` on the episode "card" on episode detail pages

![image](https://github.com/user-attachments/assets/69315c04-3ec9-4010-8591-e03c9c7631c6)

